### PR TITLE
Pr/task/clinic-nc-project-base/webrtc-stub

### DIFF
--- a/Frontend/AGENTS.md
+++ b/Frontend/AGENTS.md
@@ -616,5 +616,42 @@ export const BusinessRules = {
 
 ---
 
-**Última actualización**: 29 de octubre de 2025  
-**Versión**: 1.3 (Agregado: Guía de Features, Patrón Container)
+## 📡 WebRTC (Teleasistencia)
+
+### Estado Actual: Stub Arquitectónico
+
+La funcionalidad de **videollamadas seguras** para teleconsultas se implementará en una feature futura dedicada (`/src/features/video-call`).
+
+**Por ahora existe:**
+- 📄 Stub en `/src/shared/core/webrtc-stub.ts` como marcador arquitectónico
+- ⚠️ **NO es funcional** - solo documenta la intención y estructura futura
+- 🚫 **NO hay dependencias instaladas** (simple-peer, socket.io, etc.)
+
+**Implementación futura incluirá:**
+- Configuración de servidores TURN/STUN
+- Gestión de conexiones peer-to-peer con WebRTC
+- Señalización via WebSocket (socket.io)
+- Manejo de streams de audio/video
+- Control de permisos de cámara/micrófono
+- UI de sala de videollamada
+- Grabación de sesiones (opcional)
+
+**Decisión arquitectónica:**
+- WebRTC es **lógica de dominio específica** → vivirá en su propia feature
+- No forma parte del proyecto base para evitar deuda técnica temprana
+- Se implementará cuando se defina el proveedor (Twilio, Agora, custom)
+
+**Archivo stub:**
+```typescript
+// src/shared/core/webrtc-stub.ts
+export const initWebRTC = (): void => {
+  console.warn('WebRTC stub: implementación pendiente');
+};
+```
+
+> ⚠️ **Importante**: No usar este stub en código de producción. Es solo un recordatorio.
+
+---
+
+**Última actualización**: 30 de octubre de 2025  
+**Versión**: 1.4 (Agregado: WebRTC Stub, Documentación de teleasistencia)

--- a/Frontend/src/shared/core/webrtc-stub.ts
+++ b/Frontend/src/shared/core/webrtc-stub.ts
@@ -1,0 +1,63 @@
+/**
+ * STUB: WebRTC para teleasistencia
+ * 
+ * Este archivo es un marcador de lugar arquitectónico.
+ * La implementación real se hará en la feature `video-call`,
+ * con librerías como simple-peer, socket.io y TURN/STUN servers.
+ * 
+ * NO USAR en producción. Solo para recordar la necesidad.
+ * 
+ * @module webrtc-stub
+ * @see /src/features/video-call (implementación futura)
+ */
+
+/**
+ * Función stub para inicialización de WebRTC
+ * 
+ * Esta función no hace nada real. Es solo un placeholder.
+ * La implementación real incluirá:
+ * - Configuración de TURN/STUN servers
+ * - Gestión de conexiones peer-to-peer
+ * - Manejo de streams de audio/video
+ * - Señalización via WebSocket (socket.io)
+ * - Gestión de permisos de medios
+ * 
+ * @returns {void}
+ */
+export const initWebRTC = (): void => {
+  if (process.env.NODE_ENV === 'development') {
+    console.warn(
+      '⚠️ WebRTC stub: implementación pendiente en módulo video-call'
+    );
+  }
+};
+
+/**
+ * Configuración stub para servidores STUN/TURN
+ * 
+ * En la implementación real, estos valores vendrán de variables de entorno
+ * y se configurarán según el proveedor de infraestructura (Twilio, Agora, etc.)
+ */
+export const WEBRTC_CONFIG = {
+  iceServers: [
+    // Placeholder - reemplazar con servidores reales
+    { urls: 'stun:stun.example.com:3478' },
+  ],
+} as const;
+
+/**
+ * Tipos stub para la futura implementación
+ */
+export interface WebRTCConnectionStub {
+  id: string;
+  status: 'pending' | 'connected' | 'disconnected';
+  // Más propiedades se definirán en la feature real
+}
+
+/**
+ * @deprecated Este es solo un stub. No usar en código de producción.
+ */
+export default {
+  initWebRTC,
+  WEBRTC_CONFIG,
+};


### PR DESCRIPTION
# 📡 `[BASE] Stub inicial para WebRTC (solo placeholder)`

## 📸 Screenshot
![Clínica NC](https://i.imgur.com/QJArdn7.png)

## 📌 Issue Relacionado
- Closes #23 

## 📌 Descripción del PR

Esta PR **agrega un marcador arquitectónico simbólico** para la futura funcionalidad de **teleasistencia por videollamada** en Clínica NC.

> ✅ **No se instalan librerías**, **no se configura WebRTC real**, y **no se escribe lógica funcional**.  
> Solo se crea un **archivo stub mínimo** en `/src/shared/core/` para:
> - Documentar la intención técnica temprana
> - Evitar que se olvide la necesidad de videollamadas seguras
> - Preparar el lugar donde vivirá la lógica real (en la feature `video-call`)

> 🎯 Esto respeta el principio del proyecto base: **solo fundación, nada de lógica de negocio**.

---

## ✅ Cambios incluidos

### 1. **Archivo stub**
- Ruta: `/src/shared/core/webrtc-stub.ts`
- Contenido: solo un comentario y una función de advertencia

```ts
// src/shared/core/webrtc-stub.ts
/**
 * STUB: WebRTC para teleasistencia
 * 
 * Este archivo es un marcador de lugar.
 * La implementación real se hará en la feature `video-call`,
 * con librerías como simple-peer, socket.io y TURN/STUN servers.
 * 
 * NO USAR en producción. Solo para recordar la necesidad.
 */
export const initWebRTC = () => {
  console.warn('WebRTC stub: implementación pendiente en módulo video-call');
};
```

### 2. **Documentación en AGENTS.md**
- Sección breve que explica el propósito del stub y la futura feature

## 📡 WebRTC (Teleasistencia)

La funcionalidad de videollamadas se implementará en una feature futura (`video-call`).  
Por ahora, existe un stub en `/src/shared/core/webrtc-stub.ts` como recordatorio arquitectónico.

---

## 🚀 Cómo validar

```bash
npm run dev
```

- ✅ El archivo `webrtc-stub.ts` existe en la ruta correcta
- ✅ No hay librerías de WebRTC en `package.json`
- ✅ La app inicia sin errores
- ✅ `npm run build` compila sin problemas

---

## 🧪 Checklist de validación

- [x] Archivo stub creado en `/src/shared/core/webrtc-stub.ts`
- [x] Sin dependencias externas ni librerías instaladas
- [x] Documentación actualizada en `AGENTS.md`
- [x] Proyecto compila y corre sin errores
- [x] No se usa el stub en ningún componente ni layout

---

## 🔀 Estrategia de merge

- **Rama**: `task/clinic-nc-project-base/webrtc-stub`
- **Destino**: `feat/clinic-nc-project-base`
- **No se mergea directamente a `dev`**

---

## 📝 Notas clave

- **WebRTC es lógica de dominio**, no del proyecto base → se implementará en su propia feature.
- **Este stub no es funcional**: es puramente documental y arquitectónico.
- **Alineado con tu enfoque de Software Architect**: evita deuda técnica temprana y mantiene el base minimalista.
- **Prepara el camino** para una futura integración limpia con TURN/STUN, sockets y seguridad E2E.

---

Asignado: @davidcoachdev  
Estado: ✅ **Listo para review y merge**  
Fecha: 30 de octubre de 2025